### PR TITLE
번역기에 파파고 WEB 추가

### DIFF
--- a/lib/system/logic_trans.py
+++ b/lib/system/logic_trans.py
@@ -71,6 +71,8 @@ class SystemLogicTrans(object):
                 return SystemLogicTrans.trans_papago(source)
             elif trans_type == '3':
                 return SystemLogicTrans.trans_google_web(source)
+            elif trans_type == '4':
+                return SystemLogicTrans.trans_papago_web(source)
         except Exception as exception: 
             logger.error('Exception:%s', exception)
             logger.error(traceback.format_exc())
@@ -88,6 +90,8 @@ class SystemLogicTrans(object):
                 return SystemLogicTrans.trans_papago(text, source, target) 
             elif trans_type == '3':
                 return SystemLogicTrans.trans_google_web(text, source, target) 
+            elif trans_type == '4':
+                return SystemLogicTrans.trans_papago_web(text, source, target)
         except Exception as exception: 
             logger.error('Exception:%s', exception)
             logger.error(traceback.format_exc())
@@ -122,8 +126,32 @@ class SystemLogicTrans(object):
                 logger.error('Exception:%s', exception)
                 logger.error(traceback.format_exc())                
         return text
-
     
+    
+    '''
+    source 값은 필요 없지만 호환성을 위해서 남겨 놓음.
+    '''
+    @staticmethod
+    def trans_papago_web(text, source='ja', target='ko'):
+        if app.config['config']['is_py2']:
+            return u'Python >=3 '
+        try:
+            from papagopy import Papagopy
+        except:
+            try: os.system("{} install --upgrade papagopy".format(app.config['config']['pip']))
+            except: pass
+            from papagopy import Papagopy
+        try:
+            translator = Papagopy()
+            translate_text = translator.translate(text, sourceCode=source, targetCode=target)
+            return translate_text
+        except Exception as exception:
+            logger.error('Exception:%s', exception)
+            logger.error(traceback.format_exc())
+            return text
+
+
+
     @staticmethod
     def trans_name(name):
         trans_papago_key = ModelSetting.get_list('trans_papago_key')

--- a/lib/system/logic_trans.py
+++ b/lib/system/logic_trans.py
@@ -151,7 +151,6 @@ class SystemLogicTrans(object):
             return text
 
 
-
     @staticmethod
     def trans_name(name):
         trans_papago_key = ModelSetting.get_list('trans_papago_key')
@@ -183,7 +182,6 @@ class SystemLogicTrans(object):
                 logger.error('Exception:%s', exception)
                 logger.error(traceback.format_exc())                
         return        
-
 
 
 

--- a/lib/system/templates/system_setting_trans.html
+++ b/lib/system/templates/system_setting_trans.html
@@ -13,7 +13,7 @@
   <form id='setting' name='setting'>  
   <div class="tab-content" id="nav-tabContent">
     {{ macros.m_tab_content_start('normal', true) }}
-      {{ macros.setting_radio('trans_type', '번역', ['사용안함', '구글 API', '파파고', '구글 WEB'], value=arg['trans_type']) }}
+      {{ macros.setting_radio('trans_type', '번역', ['사용안함', '구글 API', '파파고', '구글 WEB', '파파고 WEB'], value=arg['trans_type']) }}
       <div id="google_div" class="collapse">
       {{ macros.setting_input_text('trans_google_api_key', '구글 번역 API 키', value=arg['trans_google_api_key']) }}
       </div>


### PR DESCRIPTION
번역에 구글 WEB생겼길래 파파고 WEB도 추가해봤습니다.

api키 없이 사용 가능합니다.

모듈은 [papagopy](https://pypi.org/project/papagopy) 사용했고 python3 이상 환경이면 작동합니다.
