### PR TITLE
papagopy 설치/업그레이드 로직을 맨 상단으로 옮겼습니다.

### DIFF
--- a/lib/system/logic_trans.py
+++ b/lib/system/logic_trans.py
@@ -18,6 +18,14 @@ from framework.util import Util
 from .plugin import package_name, logger
 from .model import ModelSetting
 
+# 외부 패키지 업데이트 확인
+try:
+    os.system("{} install --upgrade papagopy".format(app.config['config']['pip']))
+    from papagopy import Papagopy
+except:
+    pass
+
+
 class SystemLogicTrans(object):
     @staticmethod
     def process_ajax(sub, req):
@@ -135,12 +143,6 @@ class SystemLogicTrans(object):
     def trans_papago_web(text, source='ja', target='ko'):
         if app.config['config']['is_py2']:
             return u'Python >=3 '
-        try:
-            from papagopy import Papagopy
-        except:
-            try: os.system("{} install --upgrade papagopy".format(app.config['config']['pip']))
-            except: pass
-            from papagopy import Papagopy
         try:
             translator = Papagopy()
             translate_text = translator.translate(text, sourceCode=source, targetCode=target)


### PR DESCRIPTION
메타데이터 플러그인에 파파고 web 추가하면서
papagopy에 빈 문자열 필터가 없다는걸 이제야 알아차렸습니다.
그거때문에 이름/역할 번역시에 10초 정도의 지연시간이 발생합니다.

papagopy패키지는 패치했는데 0.1.4 -> 0.1.5
**SJVA에서는 패키지가 한번 설치된 상태면 최신 패키지를 확인하지 않는다고 생각해서** 
(위 부분이 아니라면 풀 리퀘스트 거절해주세요)
SJVA 재시작마다 패키지 최신버전 확인하도록 수정했습니다.